### PR TITLE
fix: correct typo in windows download url

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -58,7 +58,7 @@ document.addEventListener('DOMContentLoaded', function () {
     switch (OSName) {
         case "win":
             download.innerText = "Download for Windows";
-            download.setAttribute("href", "https://github.com/lapce/lapce/releases/download/v0.0.12Lapce-windows.msi")
+            download.setAttribute("href", "https://github.com/lapce/lapce/releases/download/v0.0.12/Lapce-windows.msi")
             break;
         case "mac":
             download.innerText = "Download for macOS";


### PR DESCRIPTION
Tried to download this earlier, but noticed that the link was missing a `/`.