### PR TITLE
Replace "build in" with "built-in" to avoid confusion

### DIFF
--- a/index.html
+++ b/index.html
@@ -174,7 +174,7 @@
               </div>
               <h3 class="mb-4 text-xl md:text-2xl leading-tight font-bold">Batteries included</h3>
               <p class="text-coolGray-500 font-medium">Code syntax highlighting using Tree-sitter, much
-                faster and better than regex based highlighting. Also with built in LSP support, to give you code
+                faster and better than regex based highlighting. Also with built-in LSP support, to give you code
                 intelligence like code completion, diagnostics and code actions etc.</p>
             </div>
           </div>
@@ -189,7 +189,7 @@
                 </svg>
               </div>
               <h3 class="mb-4 text-xl md:text-2xl leading-tight font-bold">Vim like modal editing</h3>
-              <p class="text-coolGray-500 font-medium">Vim users, we've got you covered! Built in support for a Vim like
+              <p class="text-coolGray-500 font-medium">Vim users, we've got you covered! Built-in support for a Vim like
                 editing experience, without a plugin.</p>
             </div>
           </div>
@@ -229,7 +229,7 @@
                   </g>
                 </svg>
               </div>
-              <h3 class="mb-4 text-xl md:text-2xl leading-tight font-bold">Built in Terminal</h3>
+              <h3 class="mb-4 text-xl md:text-2xl leading-tight font-bold">Built-in Terminal</h3>
               <p class="text-coolGray-500 font-medium">Start a terminal at the path of your workspace, without leaving
                 Lapce.</p>
             </div>


### PR DESCRIPTION
I was confused the first time I visited the website. Therefore, I think this PR might be helpful.

* "Built in Terminal": Something was built in the terminal.
* "Built-in Terminal": Something has a built-in terminal.