### PR TITLE
feat: add lapce-vue to volts2

### DIFF
--- a/volts2
+++ b/volts2
@@ -1,170 +1,178 @@
 [
-    {
-        "name": "lapce-rust",
-        "version": "0.1.12",
-        "display-name": "Rust",
-        "author": "Lapce",
-        "description": "Rust for Lapce: powered by Rust Analyzer",
-        "meta": "https://raw.githubusercontent.com/lapce/lapce-rust/master/volt.toml"
-    },
-    {
-        "name": "lapce-cpp-clangd",
-        "version": "1.0.0",
-        "display-name": "C/C++ (clangd)",
-        "author": "panekj",
-        "description": "C/C++ for Lapce: powered by clangd",
-        "meta": "https://raw.githubusercontent.com/lapce-community/lapce-cpp-clangd/HEAD/volt.toml"
-    },
-    {
-        "name": "lapce-typescript",
-        "version": "1.0.0",
-        "display-name": "Typescript / Javascript",
-        "author": "panekj",
-        "description": "TS/JS for Lapce: powered by typescript-language-server",
-        "meta": "https://raw.githubusercontent.com/panekj/lapce-typescript/HEAD/volt.toml"
-    },
-    {
-        "name": "lapce-yaml",
-        "version": "0.0.1",
-        "display-name": "YAML",
-        "author": "panekj",
-        "description": "YAML for Lapce: powered by yaml-language-server",
-        "meta": "https://raw.githubusercontent.com/lapce-community/lapce-yaml/HEAD/volt.toml"
-    },
-    {
-        "name": "lapce-python",
-        "version": "0.3.0",
-        "display-name": "Python",
-        "author": "various",
-        "description": "Python for Lapce using python-lsp-server",
-        "meta": "https://raw.githubusercontent.com/superlou/lapce-python/volt/plugin.toml"
-    },
-    {
-        "name": "lapce-dart",
-        "version": "0.0.1",
-        "display-name": "Dart",
-        "author": "zarathir",
-        "description": "Dart for Lapce: powered by dart language-server",
-        "meta": "https://raw.githubusercontent.com/zarathir/lapce-dart/master/volt.toml"
-    },
-    {
-        "name": "aleph",
-        "version": "0.3.0",
-        "display-name": "Aleph",
-        "author": "MinusGix",
-        "description": "Dark and colorful theme",
-        "meta": "https://raw.githubusercontent.com/MinusGix/lapce-aleph/master/plugin.toml"
-    },
-    {
-        "name": "solarized",
-        "version": "0.1.2",
-        "display-name": "Solarized",
-        "author": "VixieTSQ",
-        "description": "Lapce themes for dark and light solarized",
-        "meta": "https://raw.githubusercontent.com/VixieTSQ/lapce-solarized/main/plugin.toml"
-    },
-    {
-        "name": "lightpink",
-        "version": "0.2.2",
-        "display-name": "Light Pink",
-        "author": "ghishadow",
-        "description": "Cute Light Pink",
-        "meta": "https://raw.githubusercontent.com/ghishadow/light-pink-theme/main/plugin.toml"
-    },
-    {
-        "name": "lapce-adwaita",
-        "version": "0.1.1",
-        "display-name": "Adwaita",
-        "author": "Kirottu",
-        "description": "Lapce adaptation of the Adwaita color scheme",
-        "meta": "https://raw.githubusercontent.com/Kirottu/lapce-adwaita/master/plugin.toml"
-    },
-    {
-        "name": "gruvbox-ish",
-        "version": "0.1.0",
-        "display-name": "Gruvbox-ish",
-        "author": "Zooce",
-        "description": "Kind of like Gruvbox",
-        "meta": "https://raw.githubusercontent.com/Zooce/lapce-gruvbox-ish/main/plugin.toml"
-    },
-    {
-        "name": "catppuccin",
-        "version": "0.1.8",
-        "display-name": "Catppuccin",
-        "author": "ghishadow",
-        "description": "🐭 Soothing pastel theme for Lapce",
-        "meta": "https://raw.githubusercontent.com/ghishadow/lapce-catppuccin/main/plugin.toml"
-    },
-    {
-        "name": "sweet-raw",
-        "version": "0.0.3",
-        "display-name": "Sweet Raw",
-        "author": "felipetesc",
-        "description": "Dark theme inspired on Sweet Theme",
-        "meta": "https://raw.githubusercontent.com/felipetesc/lapce-sweetraw-theme/main/plugin.toml"
-    },
-    {
-        "name": "discord",
-        "version": "0.1.1",
-        "display-name": "Discord",
-        "author": "SleepyKitten",
-        "description": "Discord like theme",
-        "meta": "https://raw.githubusercontent.com/Sleepy-Kitten/lapce-discord/main/volt.toml"
-    },
-    {
-        "name": "dark-forest",
-        "version": "0.1.0",
-        "display-name": "Dark Forest",
-        "author": "MinusGix",
-        "description": "A dimly lit forest",
-        "meta": "https://raw.githubusercontent.com/MinusGix/lapce-dark-forest/master/plugin.toml"
-    },
-    {
-        "name": "monokai-pro",
-        "version": "0.0.2",
-        "display-name": "Monokai Pro",
-        "author": "jath03",
-        "description": "Monokai Pro theme generated using subtheme",
-        "meta": "https://raw.githubusercontent.com/jath03/lapce-monokai-pro/master/plugin.toml"
-    },
-    {
-        "name": "rose-pine",
-        "version": "0.1.9",
-        "display-name": "Rosé Pine",
-        "author": "ghishadow",
-        "description": "Soho vibes for Lapce",
-        "meta": "https://raw.githubusercontent.com/ghishadow/rose-pine-lapce/master/volt.toml"
-    },
-    {
-        "name": "amolapce",
-        "version": "0.0.5",
-        "display-name": "Amolapce",
-        "author": "Ereshkigal",
-        "description": "True dark theme for lapce",
-        "meta": "https://raw.githubusercontent.com/Ereshkigal01/Amolapce/main/volt.toml"
-    },
-    {
-        "name": "black-iris",
-        "version": "0.2.0",
-        "display-name": "Black Iris",
-        "author": "p-yukusai",
-        "description": "An opinionated dark theme based on blai30's Lotus",
-        "meta": "https://raw.githubusercontent.com/p-yukusai/black-iris/main/plugin.toml"
-    },
-    {
-        "name": "material-dark-orange",
-        "version": "0.1.0",
-        "display-name": "Material Dark Orange",
-        "author": "Hector Lobato",
-        "description": "My theme based on Material Theme with orange accent color",
-        "meta": "https://raw.githubusercontent.com/HectorLobatoSilva/lapce-material-dark-theme/main/plugin.toml"
-    },
-    {
-        "name": "minimal-mistakes",
-        "version": "1.0.0",
-        "display-name": "Minimal-Mistakes",
-        "author": "Minimal-Mistakes",
-        "description": "The Iconic Minimal-Mistakes Theme",
-        "meta": "https://raw.githubusercontent.com/Minimal-Mistakes/lapce/main/plugin.toml"
-    }
+  {
+    "name": "lapce-rust",
+    "version": "0.1.12",
+    "display-name": "Rust",
+    "author": "Lapce",
+    "description": "Rust for Lapce: powered by Rust Analyzer",
+    "meta": "https://raw.githubusercontent.com/lapce/lapce-rust/master/volt.toml"
+  },
+  {
+    "name": "lapce-cpp-clangd",
+    "version": "1.0.0",
+    "display-name": "C/C++ (clangd)",
+    "author": "panekj",
+    "description": "C/C++ for Lapce: powered by clangd",
+    "meta": "https://raw.githubusercontent.com/lapce-community/lapce-cpp-clangd/HEAD/volt.toml"
+  },
+  {
+    "name": "lapce-typescript",
+    "version": "1.0.0",
+    "display-name": "Typescript / Javascript",
+    "author": "panekj",
+    "description": "TS/JS for Lapce: powered by typescript-language-server",
+    "meta": "https://raw.githubusercontent.com/panekj/lapce-typescript/HEAD/volt.toml"
+  },
+  {
+    "name": "lapce-yaml",
+    "version": "0.0.1",
+    "display-name": "YAML",
+    "author": "panekj",
+    "description": "YAML for Lapce: powered by yaml-language-server",
+    "meta": "https://raw.githubusercontent.com/lapce-community/lapce-yaml/HEAD/volt.toml"
+  },
+  {
+    "name": "lapce-python",
+    "version": "0.3.0",
+    "display-name": "Python",
+    "author": "various",
+    "description": "Python for Lapce using python-lsp-server",
+    "meta": "https://raw.githubusercontent.com/superlou/lapce-python/volt/plugin.toml"
+  },
+  {
+    "name": "lapce-dart",
+    "version": "0.0.1",
+    "display-name": "Dart",
+    "author": "zarathir",
+    "description": "Dart for Lapce: powered by dart language-server",
+    "meta": "https://raw.githubusercontent.com/zarathir/lapce-dart/master/volt.toml"
+  },
+  {
+    "name": "lapce-vue",
+    "version": "0.0.1",
+    "display-name": "Vue",
+    "author": "xiaoxin-sky",
+    "description": "Vue for Lapce: powered by volar",
+    "meta": "https://raw.githubusercontent.com/xiaoxin-sky/lapce-vue/master/volt.toml"
+  },
+  {
+    "name": "aleph",
+    "version": "0.3.0",
+    "display-name": "Aleph",
+    "author": "MinusGix",
+    "description": "Dark and colorful theme",
+    "meta": "https://raw.githubusercontent.com/MinusGix/lapce-aleph/master/plugin.toml"
+  },
+  {
+    "name": "solarized",
+    "version": "0.1.2",
+    "display-name": "Solarized",
+    "author": "VixieTSQ",
+    "description": "Lapce themes for dark and light solarized",
+    "meta": "https://raw.githubusercontent.com/VixieTSQ/lapce-solarized/main/plugin.toml"
+  },
+  {
+    "name": "lightpink",
+    "version": "0.2.2",
+    "display-name": "Light Pink",
+    "author": "ghishadow",
+    "description": "Cute Light Pink",
+    "meta": "https://raw.githubusercontent.com/ghishadow/light-pink-theme/main/plugin.toml"
+  },
+  {
+    "name": "lapce-adwaita",
+    "version": "0.1.1",
+    "display-name": "Adwaita",
+    "author": "Kirottu",
+    "description": "Lapce adaptation of the Adwaita color scheme",
+    "meta": "https://raw.githubusercontent.com/Kirottu/lapce-adwaita/master/plugin.toml"
+  },
+  {
+    "name": "gruvbox-ish",
+    "version": "0.1.0",
+    "display-name": "Gruvbox-ish",
+    "author": "Zooce",
+    "description": "Kind of like Gruvbox",
+    "meta": "https://raw.githubusercontent.com/Zooce/lapce-gruvbox-ish/main/plugin.toml"
+  },
+  {
+    "name": "catppuccin",
+    "version": "0.1.8",
+    "display-name": "Catppuccin",
+    "author": "ghishadow",
+    "description": "🐭 Soothing pastel theme for Lapce",
+    "meta": "https://raw.githubusercontent.com/ghishadow/lapce-catppuccin/main/plugin.toml"
+  },
+  {
+    "name": "sweet-raw",
+    "version": "0.0.3",
+    "display-name": "Sweet Raw",
+    "author": "felipetesc",
+    "description": "Dark theme inspired on Sweet Theme",
+    "meta": "https://raw.githubusercontent.com/felipetesc/lapce-sweetraw-theme/main/plugin.toml"
+  },
+  {
+    "name": "discord",
+    "version": "0.1.1",
+    "display-name": "Discord",
+    "author": "SleepyKitten",
+    "description": "Discord like theme",
+    "meta": "https://raw.githubusercontent.com/Sleepy-Kitten/lapce-discord/main/volt.toml"
+  },
+  {
+    "name": "dark-forest",
+    "version": "0.1.0",
+    "display-name": "Dark Forest",
+    "author": "MinusGix",
+    "description": "A dimly lit forest",
+    "meta": "https://raw.githubusercontent.com/MinusGix/lapce-dark-forest/master/plugin.toml"
+  },
+  {
+    "name": "monokai-pro",
+    "version": "0.0.2",
+    "display-name": "Monokai Pro",
+    "author": "jath03",
+    "description": "Monokai Pro theme generated using subtheme",
+    "meta": "https://raw.githubusercontent.com/jath03/lapce-monokai-pro/master/plugin.toml"
+  },
+  {
+    "name": "rose-pine",
+    "version": "0.1.9",
+    "display-name": "Rosé Pine",
+    "author": "ghishadow",
+    "description": "Soho vibes for Lapce",
+    "meta": "https://raw.githubusercontent.com/ghishadow/rose-pine-lapce/master/volt.toml"
+  },
+  {
+    "name": "amolapce",
+    "version": "0.0.5",
+    "display-name": "Amolapce",
+    "author": "Ereshkigal",
+    "description": "True dark theme for lapce",
+    "meta": "https://raw.githubusercontent.com/Ereshkigal01/Amolapce/main/volt.toml"
+  },
+  {
+    "name": "black-iris",
+    "version": "0.2.0",
+    "display-name": "Black Iris",
+    "author": "p-yukusai",
+    "description": "An opinionated dark theme based on blai30's Lotus",
+    "meta": "https://raw.githubusercontent.com/p-yukusai/black-iris/main/plugin.toml"
+  },
+  {
+    "name": "material-dark-orange",
+    "version": "0.1.0",
+    "display-name": "Material Dark Orange",
+    "author": "Hector Lobato",
+    "description": "My theme based on Material Theme with orange accent color",
+    "meta": "https://raw.githubusercontent.com/HectorLobatoSilva/lapce-material-dark-theme/main/plugin.toml"
+  },
+  {
+    "name": "minimal-mistakes",
+    "version": "1.0.0",
+    "display-name": "Minimal-Mistakes",
+    "author": "Minimal-Mistakes",
+    "description": "The Iconic Minimal-Mistakes Theme",
+    "meta": "https://raw.githubusercontent.com/Minimal-Mistakes/lapce/main/plugin.toml"
+  }
 ]


### PR DESCRIPTION
lapce-vue is  ready to use. This PR adds the lapce-vue plugin to the plugin repo.